### PR TITLE
#68 - adds gradient and rounded options

### DIFF
--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -11,6 +11,8 @@
 				:indeterminate="indeterminate"
 				:counter-clockwise="counterClockwise"
 				:hide-background="hideBackground"
+				:gradient="gradient"
+				:rounded="rounded"
 				size="64"
 				rotate
 				fillDuration="2"
@@ -22,15 +24,19 @@
 				:indeterminate="indeterminate"
 				:counter-clockwise="counterClockwise"
 				:hide-background="hideBackground"
+				:gradient="gradient"
+				:rounded="rounded"
 				shape="semicircle"
 				size="64"
 			/>
-			
+
 			<loading-progress
 				:progress="progress"
 				:indeterminate="indeterminate"
 				:counter-clockwise="counterClockwise"
 				:hide-background="hideBackground"
+				:gradient="gradient"
+				:rounded="rounded"
 				shape="line"
 				size="200"
 				width="200"
@@ -42,6 +48,8 @@
 				:indeterminate="indeterminate"
 				:counter-clockwise="counterClockwise"
 				:hide-background="hideBackground"
+				:gradient="gradient"
+				:rounded="rounded"
 				shape="square"
 				size="64"
 				fill-duration="2"
@@ -52,6 +60,8 @@
 				:indeterminate="indeterminate"
 				:counter-clockwise="counterClockwise"
 				:hide-background="hideBackground"
+				:gradient="gradient"
+				:rounded="rounded"
 				shape="M10 80 C 40 10, 65 10, 95 80 S 150 150, 180 80"
 				size="180"
 				fill-duration="2"
@@ -62,6 +72,8 @@
 				:indeterminate="indeterminate"
 				:counter-clockwise="counterClockwise"
 				:hide-background="hideBackground"
+				:gradient="gradient"
+				:rounded="rounded"
 				shape="M50,3l12,36h38l-30,22l11,36l-31-21l-31,21l11-36l-30-22h38z"
 				size="100"
 				fill-duration="2"
@@ -109,6 +121,26 @@
 					hide background
 				</label>
 			</div>
+
+			<div>
+				<label>
+					<input
+						type="checkbox"
+						v-model="withGradient"
+					/>
+					with gradient
+				</label>
+			</div>
+
+			<div>
+				<label>
+					<input
+						type="checkbox"
+						v-model="rounded"
+					/>
+					rounded
+				</label>
+			</div>
 		</div>
 	</div>
 </template>
@@ -128,6 +160,8 @@ export default {
 			progress: 0,
 			counterClockwise: false,
 			hideBackground: false,
+			withGradient: false,
+			rounded: false,
 			installCode,
 			usageCode,
 		}
@@ -146,6 +180,16 @@ export default {
 		progressDisplay () {
 			return `${Math.round(this.progress * 100)}%`
 		},
+
+		gradient () {
+			return this.withGradient ?
+				[
+					{ offset: 0, color: '#25ba00'},
+					{ offset: 50, color: '#ffc000'},
+					{ offset: 100, color: '#FF0000'},
+				]
+				: false
+		}
 	},
 }
 </script>

--- a/dist/vue-progress-path.esm.js
+++ b/dist/vue-progress-path.esm.js
@@ -14,7 +14,9 @@ var shapes = {
 };
 
 var Progress$$1 = { render: function render() {
-		var _vm = this;var _h = _vm.$createElement;var _c = _vm._self._c || _h;return _c('div', { staticClass: "vue-progress-path", class: _vm.cssClass, style: _vm.style }, [_c('svg', { attrs: { "width": _vm.finalWidth, "height": _vm.finalHeight, "viewBox": '0 0 ' + _vm.finalWidth + ' ' + _vm.finalHeight } }, [_c('g', { attrs: { "transform": 'translate(' + (_vm.finalWidth - _vm.size) / 2 + ', ' + (_vm.finalHeight - _vm.size) / 2 + ') rotate(' + _vm.finalRotation + ', ' + _vm.size / 2 + ', ' + _vm.size / 2 + ')' } }, [_c('g', { staticClass: "container" }, [!_vm.hideBackground ? _c('path', { staticClass: "background", attrs: { "d": _vm.path } }) : _vm._e(), _c('path', { ref: "path", staticClass: "progress", attrs: { "d": _vm.path, "stroke-dasharray": _vm.finalDasharray + ' ' + _vm.finalDasharray, "stroke-dashoffset": _vm.finalDashoffset } })])])])]);
+		var _vm = this;var _h = _vm.$createElement;var _c = _vm._self._c || _h;return _c('div', { staticClass: "vue-progress-path", class: _vm.cssClass, style: _vm.style }, [_c('svg', { attrs: { "width": _vm.finalWidth, "height": _vm.finalHeight, "viewBox": '0 0 ' + _vm.finalWidth + ' ' + _vm.finalHeight } }, [_c('defs', [_vm.hasGradient ? _c('linearGradient', { attrs: { "id": 'progressGradient-' + _vm._uid, "gradientUnits": "userSpaceOnUse" } }, _vm._l(_vm.gradient, function (color, index) {
+			return _c('stop', { key: color.color + '-' + index, attrs: { "offset": color.offset + '%', "stop-color": color.color } });
+		})) : _vm._e()], 1), _c('g', { attrs: { "transform": 'translate(' + (_vm.finalWidth - _vm.size) / 2 + ', ' + (_vm.finalHeight - _vm.size) / 2 + ') rotate(' + _vm.finalRotation + ', ' + _vm.size / 2 + ', ' + _vm.size / 2 + ')' } }, [_c('g', { staticClass: "container" }, [!_vm.hideBackground ? _c('path', { staticClass: "background", attrs: { "stroke-linecap": _vm.rounded ? 'round' : '', "d": _vm.path } }) : _vm._e(), _c('path', { ref: "path", class: { 'progress': !_vm.hasGradient }, attrs: { "d": _vm.path, "stroke-linecap": _vm.rounded ? 'round' : '', "stroke": 'url(#progressGradient-' + _vm._uid + ')', "stroke-dasharray": _vm.finalDasharray + ' ' + _vm.finalDasharray, "stroke-dashoffset": _vm.finalDashoffset } })])])])]);
 	}, staticRenderFns: [],
 	name: 'Progress',
 
@@ -69,6 +71,14 @@ var Progress$$1 = { render: function render() {
 		width: {
 			type: [String, Number],
 			default: 0
+		},
+		gradient: {
+			type: [Array, Boolean],
+			default: false
+		},
+		rounded: {
+			type: Boolean,
+			default: false
 		}
 	},
 
@@ -142,6 +152,9 @@ var Progress$$1 = { render: function render() {
 				}
 				return path;
 			}
+		},
+		hasGradient: function hasGradient() {
+			return Array.isArray(this.gradient);
 		}
 	},
 
@@ -252,7 +265,6 @@ var plugin = {
 	}
 };
 
-// Auto-install
 var GlobalVue = null;
 if (typeof window !== 'undefined') {
 	GlobalVue = window.Vue;

--- a/src/components/Progress.vue
+++ b/src/components/Progress.vue
@@ -7,17 +7,32 @@
 			:width="finalWidth"
 			:height="finalHeight"
 			:viewBox="`0 0 ${finalWidth} ${finalHeight}`">
+			<defs>
+				<linearGradient
+					v-if="hasGradient"
+					:id="`progressGradient-${_uid}`"
+					gradientUnits="userSpaceOnUse">
+					<stop
+						v-for="(color, index) in gradient"
+						:key="`${color.color}-${index}`"
+						:offset="`${color.offset}%`" :stop-color="color.color"
+					/>
+				</linearGradient>
+			</defs>
 			<g :transform="`translate(${(finalWidth - size) / 2}, ${(finalHeight - size) / 2}) rotate(${finalRotation}, ${size / 2}, ${size / 2})`">
 				<g class="container">
 					<path
 						v-if="!hideBackground"
 						class="background"
+						:stroke-linecap="rounded ? 'round' : ''"
 						:d="path"
 					/>
 					<path
 						ref="path"
-						class="progress"
+						:class="{'progress': !hasGradient}"
 						:d="path"
+						:stroke-linecap="rounded ? 'round' : ''"
+						:stroke="`url(#progressGradient-${_uid})`"
 						:stroke-dasharray="`${finalDasharray} ${finalDasharray}`"
 						:stroke-dashoffset="finalDashoffset"
 					/>
@@ -86,6 +101,14 @@ export default {
 			type: [String, Number],
 			default: 0,
 		},
+	    gradient: {
+	      type: [Array, Boolean],
+	      default: false,
+	    },
+	    rounded: {
+	      type: Boolean,
+	      default: false
+	    }
 	},
 
 	data () {
@@ -172,6 +195,10 @@ export default {
 				return path
 			}
 		},
+
+	    hasGradient() {
+	      return Array.isArray(this.gradient)
+	    },
 	},
 
 	watch: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5918271/67927862-f9348100-fbb9-11e9-8798-9aa5f2bdaebc.png)

- adds option for gradient:
```
:gradient="[
    { offset: 0, color: '#25ba00'}, 
    { offset: 50, color: '#ffc000'}, 
    { offset: 100, color: '#FF0000'}
]"
```

- adds option for rounded:
```
:rounded="true"
```

For some reason with the simple horizontal line the ends are clipped so you can't see the rounded end caps.

See updated demo.